### PR TITLE
feat : complete map view by using google map api

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,4 +57,8 @@ dependencies {
     //okHttp
     implementation "com.squareup.okhttp3:okhttp:4.9.0"
     implementation "com.squareup.okhttp3:logging-interceptor:4.9.0"
+
+    //google map
+    implementation 'com.google.android.gms:play-services-maps:18.1.0'
+    implementation 'com.google.android.gms:play-services-location:20.0.0'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,10 @@
         android:theme="@style/Theme.Playkuround"
         tools:targetApi="31">
 
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="AIzaSyAOb8MvvBNoDEsNIU1G_Jt1-7FgDVcp1Ik"/>
+
         <activity
             android:name=".activity.SplashActivity"
             android:exported="true">

--- a/app/src/main/java/com/umc/playkuround/activity/AttendanceActivity.kt
+++ b/app/src/main/java/com/umc/playkuround/activity/AttendanceActivity.kt
@@ -22,7 +22,7 @@ class AttendanceActivity : AppCompatActivity() {
 
     lateinit var binding : ActivityAttendanceBinding
 
-    private var width = 0
+    private var width = 0 // attendance container width
 
     lateinit var today : String
     lateinit var todayTv : TextView
@@ -76,26 +76,11 @@ class AttendanceActivity : AppCompatActivity() {
     }
 
     private fun screenWidth() : Int {
-        if(this.width != 0)
-            return this.width
-        val wm = applicationContext.getSystemService(Context.WINDOW_SERVICE) as WindowManager
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            val windowMetrics = wm.currentWindowMetrics
-            val insets = windowMetrics.windowInsets
-                .getInsetsIgnoringVisibility(WindowInsets.Type.systemBars())
-            windowMetrics.bounds.width() - insets.left - insets.right
-        } else {
-            val displayMetrics = DisplayMetrics()
-            wm.defaultDisplay.getMetrics(displayMetrics)
-            displayMetrics.widthPixels
-        }
+        return resources.displayMetrics.widthPixels
     }
 
     private fun toPX(dp : Int) : Int {
-        val displayMetrics = DisplayMetrics()
-        this.windowManager.defaultDisplay.getMetrics(displayMetrics)
-        val density = displayMetrics.density.toInt()
-        return dp * density
+        return (dp * resources.displayMetrics.density).toInt()
     }
 
     @SuppressLint("SetTextI18n", "SimpleDateFormat")

--- a/app/src/main/java/com/umc/playkuround/activity/MapActivity.kt
+++ b/app/src/main/java/com/umc/playkuround/activity/MapActivity.kt
@@ -1,14 +1,29 @@
 package com.umc.playkuround.activity
 
+import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
+import android.util.DisplayMetrics
+import android.util.Log
+import android.view.WindowInsets
+import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
+import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.GoogleMap
+import com.google.android.gms.maps.OnMapReadyCallback
+import com.google.android.gms.maps.SupportMapFragment
+import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.MarkerOptions
+import com.umc.playkuround.R
 import com.umc.playkuround.databinding.ActivityMapBinding
 import kotlin.random.Random
 
-class MapActivity : AppCompatActivity() {
+
+class MapActivity : AppCompatActivity(), OnMapReadyCallback {
 
     lateinit var binding : ActivityMapBinding
+    private lateinit var map : GoogleMap
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -16,12 +31,19 @@ class MapActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         binding.mapBackBtn.setOnClickListener{
-            val intent = Intent(this, MainActivity::class.java)
-            startActivity(intent)
+            finish()
         }
 
+        startGameActivity(getGames())
+
+        val mapFragment = supportFragmentManager
+            .findFragmentById(R.id.map_map_fragment) as SupportMapFragment?
+        mapFragment!!.getMapAsync(this)
+    }
+
+    private fun startGameActivity(idx : Int) {
         binding.mapClickBtn.setOnClickListener {
-            val intent : Intent = when (getGames()) {
+            val intent : Intent = when (idx) {
                 0 -> {
                     Intent(this, MiniGameQuizActivity::class.java)
                 }
@@ -41,6 +63,33 @@ class MapActivity : AppCompatActivity() {
 
     private fun getGames() : Int {
         return Random(System.currentTimeMillis()).nextInt(3)
+    }
+
+    override fun onMapReady(p0: GoogleMap) {
+        map = p0
+
+        val SEOUL = LatLng(37.56, 126.97)
+
+        val markerOptions = MarkerOptions()
+        markerOptions.position(SEOUL)
+        markerOptions.title("서울")
+        markerOptions.snippet("한국의 수도")
+        map.addMarker(markerOptions)
+
+        map.moveCamera(CameraUpdateFactory.newLatLngZoom(SEOUL, 18F))
+        map.setPadding(0, screenHeight() - toPX(102) - toPX(40), screenWidth() - toPX(70), 0)
+    }
+
+    private fun screenWidth() : Int {
+        return resources.displayMetrics.widthPixels
+    }
+
+    private fun screenHeight() : Int {
+        return resources.displayMetrics.heightPixels
+    }
+
+    private fun toPX(dp : Int) : Int {
+        return (dp * resources.displayMetrics.density).toInt()
     }
 
 }

--- a/app/src/main/res/layout/activity_map.xml
+++ b/app/src/main/res/layout/activity_map.xml
@@ -50,6 +50,16 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
+        <fragment
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/timer_tab_bar"
+            app:layout_constraintBottom_toBottomOf="parent"
+            android:id="@+id/map_map_fragment"
+            tools:context=".activity.MapActivity"
+            android:name="com.google.android.gms.maps.SupportMapFragment"/>
 
         <ImageView
             android:id="@+id/map_click_btn"
@@ -60,8 +70,6 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
             android:layout_marginBottom="48dp"/>
-
-
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
## 요약
- mapActivity의 map view 구현

<br>

## 작업 내용
- playkuround@gmail.com 계정에 cloud service 중 map api 생성 및 사용
- api key를 발급 및 제한하여 playkuround 어플에서만 접근하도록 설정
- 발급받은 key로 map view 완성
- google 로고를 좌측 하단으로 이동 및 서울에 임시 마커 생성

<br>

## 기타
- google 로고를 좌측 하단으로 설정함에 따라 마커 클릭시 마커가 좌측 하단으로 자동 이동되는 문제 존재