### PR TITLE
Sangmin

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -36,6 +36,7 @@
         <entry key="..\:/Users/rdrni/AndroidStudioProjects/playkuround/app/src/main/res/layout/dialog_badge_info.xml" value="0.25" />
         <entry key="..\:/Users/rdrni/AndroidStudioProjects/playkuround/app/src/main/res/layout/dialog_certify_timeout.xml" value="0.2858974358974359" />
         <entry key="..\:/Users/rdrni/AndroidStudioProjects/playkuround/app/src/main/res/layout/dialog_get_badge.xml" value="0.41623931623931626" />
+        <entry key="..\:/Users/rdrni/AndroidStudioProjects/playkuround/app/src/main/res/layout/dialog_loading.xml" value="0.28675213675213673" />
         <entry key="..\:/Users/rdrni/AndroidStudioProjects/playkuround/app/src/main/res/layout/dialog_place_info.xml" value="0.25" />
         <entry key="..\:/Users/rdrni/AndroidStudioProjects/playkuround/app/src/main/res/layout/dialog_place_rank.xml" value="0.3836050724637681" />
         <entry key="..\:/Users/rdrni/AndroidStudioProjects/playkuround/app/src/main/res/layout/dialog_quiz_correct.xml" value="0.28675213675213673" />

--- a/app/src/main/java/com/umc/playkuround/activity/EmailCertifyActivity.kt
+++ b/app/src/main/java/com/umc/playkuround/activity/EmailCertifyActivity.kt
@@ -118,8 +118,6 @@ class EmailCertifyActivity : AppCompatActivity() {
                 }
             }
         }).sendEmail(email)
-
-        Toast.makeText(this, "요청이 완료되었습니다.", Toast.LENGTH_SHORT).show()
     }
 
     private fun isCodeCorrect(email : String, code : String) : Boolean {

--- a/app/src/main/java/com/umc/playkuround/activity/EmailCertifyActivity.kt
+++ b/app/src/main/java/com/umc/playkuround/activity/EmailCertifyActivity.kt
@@ -18,6 +18,7 @@ import com.umc.playkuround.R
 import com.umc.playkuround.data.EmailCertifyResponse
 import com.umc.playkuround.data.EmailResponse
 import com.umc.playkuround.databinding.ActivityEmailCertifyBinding
+import com.umc.playkuround.dialog.LoadingDialog
 import com.umc.playkuround.dialog.SlideUpDialog
 import com.umc.playkuround.service.UserService
 import java.text.SimpleDateFormat
@@ -89,10 +90,13 @@ class EmailCertifyActivity : AppCompatActivity() {
 
     private fun requestCode(email : String) {
         // send email to server
+        val loading = LoadingDialog(this)
+        loading.show()
         val userService = UserService()
         userService.setOnResponseListener(object : UserService.OnResponseListener() {
             @SuppressLint("SetTextI18n")
             override fun <T> getResponseBody(body: T, isSuccess: Boolean, err: String) {
+                loading.dismiss()
                 binding.emailRequestCodeBtn.text = resources.getText(R.string.request_code_again)
                 binding.emailRequestCodeBtn.isEnabled = true
 
@@ -120,9 +124,12 @@ class EmailCertifyActivity : AppCompatActivity() {
 
     private fun isCodeCorrect(email : String, code : String) : Boolean {
         Log.d("certify code", "isCodeCorrect: email : $email, code : $code")
+        val loading = LoadingDialog(this)
+        loading.show()
         val userService = UserService()
         userService.setOnResponseListener(object : UserService.OnResponseListener() {
             override fun <T> getResponseBody(body: T, isSuccess: Boolean, err: String) {
+                loading.dismiss()
                 if(isSuccess) {
                     if(body is EmailCertifyResponse) {
                         if(body.response) // if code is correct

--- a/app/src/main/java/com/umc/playkuround/activity/NicknameActivity.kt
+++ b/app/src/main/java/com/umc/playkuround/activity/NicknameActivity.kt
@@ -17,6 +17,7 @@ import com.umc.playkuround.data.DuplicateResponse
 import com.umc.playkuround.data.User
 import com.umc.playkuround.data.UserTokenResponse
 import com.umc.playkuround.databinding.ActivityNicknameBinding
+import com.umc.playkuround.dialog.LoadingDialog
 import com.umc.playkuround.fragment.HomeFragment
 import com.umc.playkuround.service.UserService
 import kotlin.Result.Companion.success
@@ -82,30 +83,31 @@ class NicknameActivity : AppCompatActivity() {
     }
 
     private fun savename() {
-        binding.nicknameEndBtn.setOnClickListener {
-            val userService = UserService()
-            user.nickname = binding.nicknameEt.text.toString()
-            userService.setOnResponseListener(object : UserService.OnResponseListener() {
-                override fun <T> getResponseBody(body: T, isSuccess: Boolean, err: String) {
-                    if (isSuccess) {
-                        if (body is UserTokenResponse)
-                            user.userTokenResponse = body.copy()
-                        user.save(pref)
+        val loading = LoadingDialog(this)
+        loading.show()
+        val userService = UserService()
+        user.nickname = binding.nicknameEt.text.toString()
+        userService.setOnResponseListener(object : UserService.OnResponseListener() {
+            override fun <T> getResponseBody(body: T, isSuccess: Boolean, err: String) {
+                loading.dismiss()
+                if (isSuccess) {
+                    if (body is UserTokenResponse)
+                        user.userTokenResponse = body.copy()
+                    user.save(pref)
 
-                        val intent = Intent(applicationContext, MainActivity::class.java)
-                        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
-                        startActivity(intent)
-                        finish()
+                    val intent = Intent(applicationContext, MainActivity::class.java)
+                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                    startActivity(intent)
+                    finish()
 
-                        Log.d("userInfo", "onCreate: $user")
-                    } else {
-                        Log.d("retrofit", "getResponseBody: $err")
-                        Toast.makeText(applicationContext, err, Toast.LENGTH_SHORT).show()
-                    }
+                    Log.d("userInfo", "onCreate: $user")
+                } else {
+                    Log.d("retrofit", "getResponseBody: $err")
+                    Toast.makeText(applicationContext, err, Toast.LENGTH_SHORT).show()
                 }
-            }).register(user)
-        }
+            }
+        }).register(user)
     }
 
 }

--- a/app/src/main/java/com/umc/playkuround/activity/SplashActivity.kt
+++ b/app/src/main/java/com/umc/playkuround/activity/SplashActivity.kt
@@ -12,6 +12,7 @@ import com.umc.playkuround.data.RefreshTokenResponse
 import com.umc.playkuround.data.UserTokenResponse
 import com.umc.playkuround.databinding.ActivityPolicyAgreeBinding
 import com.umc.playkuround.databinding.ActivitySplashBinding
+import com.umc.playkuround.dialog.LoadingDialog
 import com.umc.playkuround.fragment.BadgeFragment
 import com.umc.playkuround.fragment.HomeFragment
 import com.umc.playkuround.service.UserService
@@ -20,6 +21,7 @@ import com.umc.playkuround.service.UserService
 class SplashActivity : AppCompatActivity() {
 
     lateinit var binding : ActivitySplashBinding
+    lateinit private var loading : LoadingDialog
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -37,6 +39,8 @@ class SplashActivity : AppCompatActivity() {
             val intent = Intent(this, LoginActivity::class.java)
             startActivity(intent)
         } else {
+            loading = LoadingDialog(this)
+            loading.show()
             login()
         }
     }
@@ -51,6 +55,7 @@ class SplashActivity : AppCompatActivity() {
                         user.userTokenResponse = body.copy()
                         user.save(pref)
 
+                        loading.dismiss()
                         val intent = Intent(applicationContext, MainActivity::class.java)
                         startActivity(intent)
                     }
@@ -58,6 +63,7 @@ class SplashActivity : AppCompatActivity() {
                     if(err == "A004") { // 유효하지 않은 토큰
                         reissuanceToken()
                     } else {
+                        loading.dismiss()
                         Log.d("login failed", "getResponseBody: $err")
                         Toast.makeText(applicationContext, "로그인에 실패하였습니다!\n다시 로그인하여 주세요.", Toast.LENGTH_SHORT).show()
 

--- a/app/src/main/java/com/umc/playkuround/activity/SplashActivity.kt
+++ b/app/src/main/java/com/umc/playkuround/activity/SplashActivity.kt
@@ -62,6 +62,10 @@ class SplashActivity : AppCompatActivity() {
                 } else {
                     if(err == "A004") { // 유효하지 않은 토큰
                         reissuanceToken()
+                    } else if(err == "서버 연결에 실패하였습니다. 네트워크를 확인해주세요.") {
+                        loading.dismiss()
+                        Toast.makeText(applicationContext, err, Toast.LENGTH_SHORT).show()
+                        finish()
                     } else {
                         loading.dismiss()
                         Log.d("login failed", "getResponseBody: $err")

--- a/app/src/main/java/com/umc/playkuround/dialog/LoadingDialog.kt
+++ b/app/src/main/java/com/umc/playkuround/dialog/LoadingDialog.kt
@@ -1,0 +1,19 @@
+package com.umc.playkuround.dialog
+
+import android.app.Dialog
+import android.content.Context
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import com.umc.playkuround.R
+
+class LoadingDialog(context : Context) : Dialog(context) {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.dialog_loading)
+        setCancelable(false)
+        window!!.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+    }
+
+}

--- a/app/src/main/java/com/umc/playkuround/service/UserService.kt
+++ b/app/src/main/java/com/umc/playkuround/service/UserService.kt
@@ -203,4 +203,6 @@ class UserService {
         })
     }
 
+
+
 }

--- a/app/src/main/res/layout/dialog_loading.xml
+++ b/app/src/main/res/layout/dialog_loading.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <ProgressBar
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:id="@+id/loading_progress_bar"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 요약
- 예외 처리 작업, 서버 응답 대기 시 로딩 화면

<br>

## 작업 내용
- 기존에 서버에 응답을 여러번 줄 수 있었던 문제 -> 다이얼로그를 활용한 로딩 화면 구현으로 해결
- SplashActivity 로그인 중 동작 일부 수정 -> 네트워크 미연결시 안내 후 자동 어플 종료

<br>

## 기타
- 닉네임 중복 확인 부분 메커니즘을 변경할 필요가 있어보임 (네트워크를 고의로 끊고 중복 닉네임으로 요청을 넣을 수 있음)